### PR TITLE
Rewrite MaxPlus as trait w/ default impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@ mod min_plus;
 mod tests {
     use crate::{max_plus::MaxPlus, min_plus::MinPlus};
     #[test]
-    fn test_basic_ops() {
-        let (a, b) = (MaxPlus(3), MaxPlus(5));
-        let (sum, product) = (a + b, a * b);
-        assert_eq!(sum, MaxPlus(5));
-        assert_eq!(product, MaxPlus(8));
+    fn test_max_plus_ops() {
+        let (a, b) = (3, 5);
+        let sum = MaxPlus::add(a, b);
+        let product = MaxPlus::mul(a, b);
+        assert_eq!(sum, 5);
+        assert_eq!(product, 8);
     }
     fn a() {
         let (a, b) = (MinPlus(3), MinPlus(5));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(associated_type_bounds)]
-
 mod max_plus;
 mod min_plus;
 
@@ -9,15 +7,15 @@ mod tests {
     #[test]
     fn test_max_plus_ops() {
         let (a, b) = (3, 5);
-        let sum = MaxPlus::add(a, b);
-        let product = MaxPlus::mul(a, b);
+        let (sum, product) = (MaxPlus::add(a, b), MaxPlus::mul(a, b));
         assert_eq!(sum, 5);
         assert_eq!(product, 8);
     }
-    fn a() {
-        let (a, b) = (MinPlus(3), MinPlus(5));
-        let (sum, product) = (a + b, a * b);
-        assert_eq!(sum, MinPlus(3));
-        assert_eq!(product, MinPlus(8));
+    #[test]
+    fn test_min_plus_ops() {
+        let (a, b) = (3, 5);
+        let (sum, product) = (MinPlus::add(a, b), MinPlus::mul(a, b));
+        assert_eq!(sum, 3);
+        assert_eq!(product, 8);
     }
 }

--- a/src/max_plus.rs
+++ b/src/max_plus.rs
@@ -1,57 +1,59 @@
-use {
-    core::ops::Neg,
-    derive_more::{Display, From},
-    num::{
-        self,
-        traits::{Bounded, One, Zero},
-    },
-    std::{
-        cmp::{max, Ord},
-        ops::{Add, Div, Mul, Sub},
-    },
-};
+use core:: ops::Neg;
+use num::traits::{Bounded, Zero};
+use std::ops::{Add, Sub};
+use std::cmp::Ord;
 
-#[derive(Clone, Copy, Debug, Display, Eq, From, Ord, PartialEq, PartialOrd)]
-pub(crate) struct MaxPlus<T>(pub(crate) T);
+pub trait MaxPlus {
+    type Output;
 
-impl<T: Ord> Add for MaxPlus<T> {
-    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output;
 
-    fn add(self, rhs: Self) -> Self::Output { Self(max(self.0, rhs.0)) }
+    fn mul(self, rhs: Self) -> Self::Output;
+
+    fn zero() -> Self;
+
+    fn is_zero(&self) -> bool;
+
+    fn min_value() -> Self;
+
+    fn max_value() -> Self;
+
+    fn neg(self) -> Self::Output;
+
+    fn div(self, rhs: Self) -> Self::Output;
 }
 
-impl<T: Add + Add<Output = T>> Mul for MaxPlus<T> {
-    type Output = Self;
+impl<T> MaxPlus for T
+where
+T:Ord
+    + Add
+    + Add<Output = T>
+    + Zero
+    + Bounded
+    + Eq
+    + Neg
+    + Neg<Output = T>
+    + Sub
+    + Sub<Output = T>
+{
+    type Output = T;
 
-    fn mul(self, rhs: Self) -> Self::Output { Self(self.0 + rhs.0) }
-}
+    fn add(self, rhs: T) -> T { self.max(rhs) }
 
-impl<T: Zero + Bounded + Ord> Zero for MaxPlus<T> {
-    fn zero() -> Self { MaxPlus(Bounded::min_value()) }
+    fn mul(self, rhs: T) -> T { self + rhs }
 
-    fn is_zero(&self) -> bool { self.0 == Bounded::min_value() }
-}
+    fn zero() -> T { Bounded::min_value() }
 
-impl<T: Zero + Eq> One for MaxPlus<T> {
-    fn one() -> Self { MaxPlus(Zero::zero()) }
+    fn is_zero(&self) -> bool {
+        let zero: T = Zero::zero();
+        self == &zero
+    }
 
-    fn is_one(&self) -> bool { self.0 == Zero::zero() }
-}
+    fn min_value() -> T { Bounded::min_value() }
 
-impl<T: Bounded> Bounded for MaxPlus<T> {
-    fn min_value() -> Self { MaxPlus(Bounded::min_value()) }
+    fn max_value() -> T { Bounded::max_value() }
 
-    fn max_value() -> Self { MaxPlus(Bounded::max_value()) }
-}
+    fn neg(self) -> T { -self }
 
-impl<T: Neg + Neg<Output = T>> Neg for MaxPlus<T> {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output { Self(-self.0) }
-}
-
-impl<T: Sub + Sub<Output = T>> Div for MaxPlus<T> {
-    type Output = Self;
-
-    fn div(self, rhs: Self) -> Self::Output { Self(self.0 - rhs.0) }
+    fn div(self, rhs: T) -> T { self - rhs }
 }

--- a/src/max_plus.rs
+++ b/src/max_plus.rs
@@ -1,7 +1,10 @@
-use core:: ops::Neg;
-use num::traits::{Bounded, Zero};
-use std::ops::{Add, Sub};
-use std::cmp::Ord;
+use {
+    num::traits::{Bounded, Zero},
+    std::{
+        cmp::Ord,
+        ops::{Add, Sub},
+    },
+};
 
 pub trait MaxPlus {
     type Output;
@@ -18,42 +21,40 @@ pub trait MaxPlus {
 
     fn max_value() -> Self;
 
-    fn neg(self) -> Self::Output;
-
     fn div(self, rhs: Self) -> Self::Output;
 }
 
 impl<T> MaxPlus for T
-where
-T:Ord
-    + Add
-    + Add<Output = T>
-    + Zero
-    + Bounded
-    + Eq
-    + Neg
-    + Neg<Output = T>
-    + Sub
-    + Sub<Output = T>
+where T: Ord
+        + Add<Output = T>
+        + Zero
+        + Bounded
+        + Eq
+        + Sub<Output = T>
 {
     type Output = T;
 
-    fn add(self, rhs: T) -> T { self.max(rhs) }
+    fn add(self, rhs: T) -> Self::Output { self.max(rhs) }
 
-    fn mul(self, rhs: T) -> T { self + rhs }
+    fn mul(self, rhs: T) -> Self::Output { self + rhs }
 
-    fn zero() -> T { Bounded::min_value() }
+    fn zero() -> Self::Output { Bounded::min_value() }
 
     fn is_zero(&self) -> bool {
-        let zero: T = Zero::zero();
-        self == &zero
+        self == &Zero::zero()
     }
 
-    fn min_value() -> T { Bounded::min_value() }
+    fn min_value() -> Self { Bounded::min_value() }
 
-    fn max_value() -> T { Bounded::max_value() }
+    fn max_value() -> Self { Bounded::max_value() }
 
-    fn neg(self) -> T { -self }
-
-    fn div(self, rhs: T) -> T { self - rhs }
+    fn div(self, rhs: T) -> Self::Output { self - rhs }
 }
+
+// // TODO 
+// #[test]
+// fn test_f64() {
+//     let a = 1.0;
+//     let b = MaxPlus::add(f64::INFINITY, a);
+//     println!("{b}");
+// }

--- a/src/min_plus.rs
+++ b/src/min_plus.rs
@@ -1,57 +1,53 @@
 use {
-    core::ops::Neg,
-    derive_more::{Display, From},
-    num::{
-        self,
-        traits::{Bounded, One, Zero},
-    },
+    num::traits::{Bounded, Zero},
     std::{
-        cmp::{min, Ord},
-        ops::{Add, Div, Mul, Sub},
+        cmp::Ord,
+        ops::{Add, Sub},
     },
 };
 
-#[derive(Clone, Copy, Debug, Display, Eq, From, Ord, PartialEq, PartialOrd)]
-pub(crate) struct MinPlus<T>(pub(crate) T);
+pub trait MinPlus {
+    type Output;
 
-impl<T: Ord> Add for MinPlus<T> {
-    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output;
 
-    fn add(self, rhs: Self) -> Self::Output { Self(min(self.0, rhs.0)) }
+    fn mul(self, rhs: Self) -> Self::Output;
+
+    fn zero() -> Self;
+
+    fn is_zero(&self) -> bool;
+
+    fn min_value() -> Self;
+
+    fn max_value() -> Self;
+
+    fn div(self, rhs: Self) -> Self::Output;
 }
 
-impl<T: Add + Add<Output = T>> Mul for MinPlus<T> {
-    type Output = Self;
+impl<T> MinPlus for T
+where T: Ord + Add<Output = T> + Zero + Bounded + Eq + Sub<Output = T>
+{
+    type Output = T;
 
-    fn mul(self, rhs: Self) -> Self::Output { Self(self.0 + rhs.0) }
+    fn add(self, rhs: T) -> Self::Output { self.min(rhs) }
+
+    fn mul(self, rhs: T) -> Self::Output { self + rhs }
+
+    fn zero() -> Self::Output { Bounded::max_value() }
+
+    fn is_zero(&self) -> bool { self == &Zero::zero() }
+
+    fn min_value() -> Self { Bounded::min_value() }
+
+    fn max_value() -> Self { Bounded::max_value() }
+
+    fn div(self, rhs: T) -> Self::Output { self - rhs }
 }
 
-impl<T: Zero + Bounded + Ord> Zero for MinPlus<T> {
-    fn zero() -> Self { MinPlus(Bounded::max_value()) }
-
-    fn is_zero(&self) -> bool { self.0 == Bounded::max_value() }
-}
-
-impl<T: Zero + Eq> One for MinPlus<T> {
-    fn one() -> Self { MinPlus(Zero::zero()) }
-
-    fn is_one(&self) -> bool { self.0 == Zero::zero() }
-}
-
-impl<T: Bounded> Bounded for MinPlus<T> {
-    fn min_value() -> Self { MinPlus(Bounded::min_value()) }
-
-    fn max_value() -> Self { MinPlus(Bounded::max_value()) }
-}
-
-impl<T: Neg + Neg<Output = T>> Neg for MinPlus<T> {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output { Self(-self.0) }
-}
-
-impl<T: Sub + Sub<Output = T>> Div for MinPlus<T> {
-    type Output = Self;
-
-    fn div(self, rhs: Self) -> Self::Output { Self(self.0 - rhs.0) }
-}
+// // TODO
+// #[test]
+// fn test_f64() {
+//     let a = 1.0;
+//     let b = MinPlus::add(f64::INFINITY, a);
+//     println!("{b}");
+// }


### PR DESCRIPTION
This PR refactors the previous `MaxPlus` struct into a `MaxPlus` trait. The existing functionality is reused as a default trait implementation in `max_plus.rs`. I'd suggest doing the same for `MinPlus`.

Since `MaxPlus` / `MinPlus` are describing custom behavior of other types, and are not naturally types themselves, I think they would work better as traits. This allows implementers to extend the `MaxPlus` behavior beyond `T` satisfying the trait bounds of `MaxPlus`without having to define a whole new struct.

Also gitignores Cargo.lock, per the suggestion [here](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html#cargotoml-vs-cargolock).